### PR TITLE
Add rustc-dep-of-std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,12 @@ license = "MIT OR Apache-2.0 OR LGPL-2.1-or-later"
 readme = "README.md"
 repository = "https://github.com/r-efi/r-efi-alloc"
 
+[dependencies]
+r-efi = "4.0.0"
+# Required setup to build as part of rustc.
+compiler_builtins = { version = '0.1.79', optional = true }
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+
 [features]
 # Use the unstable `allocator_api` feature of the standard library to provide
 # an allocator with the `core::alloc::Allocator` trait.
@@ -35,10 +41,9 @@ allocator_api = []
 # use a UEFI target configuration. To make `cargo test` work, we exclude all
 # examples from normal runs.
 examples = []
+# This is needed for use inside Rust std
+rustc-dep-of-std = ['compiler_builtins/rustc-dep-of-std', 'core']
 
 [[example]]
 name = "hello-world"
 required-features = ["examples"]
-
-[dependencies]
-r-efi = "4.0.0"


### PR DESCRIPTION
This is needed for using a crate in Rust std.

Sorry for not adding it before the release was published. I remembered this was required only after I actually tried adding it to std. It would be great if you could publish a new release after this is merged.

Signed-off-by: Ayush Singh <ayushsingh1325@gmail.com>